### PR TITLE
Support tag groups for Gelbooru

### DIFF
--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -273,11 +273,10 @@ fun SearchResults(navController: NavController, source: ImageSource, tagList: Li
         navController,
         isImageCarouselVisible,
         initialPage,
-        imagesToDisplay,
-        onImageUpdate = { oldImage, newImage ->
-            val index = viewModel.images.indexOf(oldImage)
-            if (index != -1) viewModel.images[index] = newImage
-        }
-    )
+        imagesToDisplay
+    ) { oldImage, newImage ->
+        val index = viewModel.images.indexOf(oldImage)
+        if (index != -1) viewModel.images[index] = newImage
+    }
 }
 

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -269,6 +269,15 @@ fun SearchResults(navController: NavController, source: ImageSource, tagList: Li
         )
     }
 
-    OffsetBasedLargeImageView(navController, isImageCarouselVisible, initialPage, imagesToDisplay)
+    OffsetBasedLargeImageView(
+        navController,
+        isImageCarouselVisible,
+        initialPage,
+        imagesToDisplay,
+        { oldImage, newImage ->
+            val index = viewModel.images.indexOf(oldImage)
+            if (index != -1) viewModel.images[index] = newImage
+        }
+    )
 }
 

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -274,7 +274,7 @@ fun SearchResults(navController: NavController, source: ImageSource, tagList: Li
         isImageCarouselVisible,
         initialPage,
         imagesToDisplay,
-        { oldImage, newImage ->
+        onImageUpdate = { oldImage, newImage ->
             val index = viewModel.images.indexOf(oldImage)
             if (index != -1) viewModel.images[index] = newImage
         }

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -142,7 +142,8 @@ fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableS
         isImageCarouselVisible,
         initialPage,
         images,
-        bottomBarVisibleState,
-        { oldImage, newImage -> preferencesRepository.updateFavouriteImage(oldImage, newImage) }
-    )
+        bottomBarVisibleState
+    ) { oldImage, newImage ->
+        preferencesRepository.updateFavouriteImage(oldImage, newImage)
+    }
 }

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -137,5 +137,12 @@ fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableS
         )
     }
 
-    OffsetBasedLargeImageView(navController, isImageCarouselVisible, initialPage, images, bottomBarVisibleState)
+    OffsetBasedLargeImageView(
+        navController,
+        isImageCarouselVisible,
+        initialPage,
+        images,
+        { oldImage, newImage -> preferencesRepository.updateFavouriteImage(oldImage, newImage) },
+        bottomBarVisibleState
+    )
 }

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -142,7 +142,7 @@ fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableS
         isImageCarouselVisible,
         initialPage,
         images,
-        { oldImage, newImage -> preferencesRepository.updateFavouriteImage(oldImage, newImage) },
-        bottomBarVisibleState
+        bottomBarVisibleState,
+        { oldImage, newImage -> preferencesRepository.updateFavouriteImage(oldImage, newImage) }
     )
 }

--- a/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
@@ -201,11 +201,19 @@ fun HomeScreen(navController: NavController, bottomBarVisibleState: MutableState
         }
     }
 
+    val recommendedImages = recommendationsProvider?.recommendedImages
+
     OffsetBasedLargeImageView(
         navController,
         shouldShowLargeImage,
         initialPage,
-        recommendationsProvider?.recommendedImages ?: emptyList(),
+        recommendedImages ?: emptyList(),
+        { oldImage, newImage ->
+            if (recommendedImages != null) {
+                val index = recommendedImages.indexOf(oldImage)
+                if (index != -1) recommendedImages[index] = newImage
+            }
+        },
         bottomBarVisibleState
     )
 }

--- a/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
@@ -208,12 +208,11 @@ fun HomeScreen(navController: NavController, bottomBarVisibleState: MutableState
         shouldShowLargeImage,
         initialPage,
         recommendedImages ?: emptyList(),
-        bottomBarVisibleState,
-        { oldImage, newImage ->
-            if (recommendedImages != null) {
-                val index = recommendedImages.indexOf(oldImage)
-                if (index != -1) recommendedImages[index] = newImage
-            }
+        bottomBarVisibleState
+    ) { oldImage, newImage ->
+        if (recommendedImages != null) {
+            val index = recommendedImages.indexOf(oldImage)
+            if (index != -1) recommendedImages[index] = newImage
         }
-    )
+    }
 }

--- a/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
@@ -208,12 +208,12 @@ fun HomeScreen(navController: NavController, bottomBarVisibleState: MutableState
         shouldShowLargeImage,
         initialPage,
         recommendedImages ?: emptyList(),
+        bottomBarVisibleState,
         { oldImage, newImage ->
             if (recommendedImages != null) {
                 val index = recommendedImages.indexOf(oldImage)
                 if (index != -1) recommendedImages[index] = newImage
             }
-        },
-        bottomBarVisibleState
+        }
     )
 }

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -60,4 +60,14 @@ data class Image(
         get() = "${imageSource}_${id ?: fileName}"
     val highestQualityFormatUrl = fileUrl.takeIf { it.isNotEmpty() } ?: sampleUrl
     val isVideo = fileFormat == "mp4" || fileFormat == "webm"
+    var metadataArtistsOverride by mutableStateOf<List<String>?>(null)
+    var metadataGroupedTagsOverride by mutableStateOf<List<TagGroup>?>(null)
+
+    fun copyWithMergedMetadataOverrides(): Image {
+        val newMetadata = metadata?.copy(
+            artists = metadataArtistsOverride ?: metadata.artists,
+            groupedTags = metadataGroupedTagsOverride ?: metadata.groupedTags
+        )
+        return this.copy(metadata = newMetadata)
+    }
 }

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -61,17 +61,10 @@ data class Image(
         get() = "${imageSource}_${id ?: fileName}"
     val highestQualityFormatUrl = fileUrl.takeIf { it.isNotEmpty() } ?: sampleUrl
     val isVideo = fileFormat == "mp4" || fileFormat == "webm"
-    var metadataArtistsOverride by mutableStateOf<List<String>?>(null)
-    var metadataGroupedTagsOverride by mutableStateOf<List<TagGroup>?>(null)
 
     val hasGroupedTags: Boolean
         get() {
-            if (
-                id == null ||
-                metadata == null ||
-                metadataArtistsOverride != null ||
-                metadataGroupedTagsOverride != null
-            ) return true
+            if (id == null || metadata == null) return true
 
             /* Usually, we can tell that the existing grouped tags are grouped properly if they have more than one group.
 
@@ -88,12 +81,4 @@ data class Image(
 
             return false
         }
-
-    fun copyWithMergedMetadataOverrides(): Image {
-        val newMetadata = metadata?.copy(
-            artists = metadataArtistsOverride ?: metadata.artists,
-            groupedTags = metadataGroupedTagsOverride ?: metadata.groupedTags
-        )
-        return this.copy(metadata = newMetadata)
-    }
 }

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -73,8 +73,8 @@ data class Image(
                Otherwise, the least we could do is make sure that the only existing group is a non-general one.
                This does not usually happen, but we would at least know that it is already grouped in this case.
 
-               The images that pass would usually have ungrouped tags, but it could also catch actual
-               images that literally only have general tags. I'm not sure how to work around this. */
+               The images that pass would usually have ungrouped tags, but it could also catch actual images that
+               literally only have general tags. They're usually due to bad tagging and should be re-fetched anyway. */
             if (
                 metadata.groupedTags.size > 1 ||
                 (metadata.groupedTags.size == 1 && metadata.groupedTags[0].category != TagCategory.GENERAL)

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -64,6 +64,8 @@ data class Image(
 
     val hasGroupedTags: Boolean
         get() {
+            /* If the image does not have ID or metadata, we would have no way of fetching additional info.
+               Therefore, the image should just be treated as already having grouped tags. */
             if (id == null || metadata == null) return true
 
             /* Usually, we can tell that the existing grouped tags are grouped properly if they have more than one group.

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import moe.apex.rule34.preferences.ImageSource
+import moe.apex.rule34.tag.TagCategory
 import moe.apex.rule34.tag.TagGroup
 import moe.apex.rule34.util.MigrationOnlyField
 
@@ -62,6 +63,42 @@ data class Image(
     val isVideo = fileFormat == "mp4" || fileFormat == "webm"
     var metadataArtistsOverride by mutableStateOf<List<String>?>(null)
     var metadataGroupedTagsOverride by mutableStateOf<List<TagGroup>?>(null)
+
+    fun hasGroupedTags(isFavourited: Boolean): Boolean {
+        if (
+            id == null ||
+            metadata == null ||
+            metadataArtistsOverride != null ||
+            metadataGroupedTagsOverride != null
+        ) return true
+
+        /* Usually, we can tell that the existing grouped tags are grouped properly if they have more than one group.
+
+           Otherwise, the least we could do is make sure that the only existing group is a non-general one.
+           This does not usually happen, but we would at least know that it is already grouped in this case.
+
+           The images that pass would usually have ungrouped tags, but it could also catch actual
+           images that literally only have general tags. I'm not sure how to work around this. */
+        if (
+            metadata.groupedTags.size > 1 ||
+            (metadata.groupedTags.size == 1 && metadata.groupedTags[0].category != TagCategory.GENERAL)
+        )
+            return true
+
+        /* These image boards would always have grouped tags when viewed outside favourites, so we skip fetching
+           additional info.
+
+           This is for a rare case where the image literally only has one tag group, and it's the general one.
+
+           Unfortunately, if it is a favourited image, we will still attempt to fetch for
+           additional info at least once, in case it was favourited before grouped tags were implemented. */
+        if (
+            !isFavourited &&
+            imageSource in setOf(ImageSource.SAFEBOORU, ImageSource.DANBOORU, ImageSource.R34)
+        ) return true
+
+        return false
+    }
 
     fun copyWithMergedMetadataOverrides(): Image {
         val newMetadata = metadata?.copy(

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -64,41 +64,30 @@ data class Image(
     var metadataArtistsOverride by mutableStateOf<List<String>?>(null)
     var metadataGroupedTagsOverride by mutableStateOf<List<TagGroup>?>(null)
 
-    fun hasGroupedTags(isFavourited: Boolean): Boolean {
-        if (
-            id == null ||
-            metadata == null ||
-            metadataArtistsOverride != null ||
-            metadataGroupedTagsOverride != null
-        ) return true
+    val hasGroupedTags: Boolean
+        get() {
+            if (
+                id == null ||
+                metadata == null ||
+                metadataArtistsOverride != null ||
+                metadataGroupedTagsOverride != null
+            ) return true
 
-        /* Usually, we can tell that the existing grouped tags are grouped properly if they have more than one group.
+            /* Usually, we can tell that the existing grouped tags are grouped properly if they have more than one group.
 
-           Otherwise, the least we could do is make sure that the only existing group is a non-general one.
-           This does not usually happen, but we would at least know that it is already grouped in this case.
+               Otherwise, the least we could do is make sure that the only existing group is a non-general one.
+               This does not usually happen, but we would at least know that it is already grouped in this case.
 
-           The images that pass would usually have ungrouped tags, but it could also catch actual
-           images that literally only have general tags. I'm not sure how to work around this. */
-        if (
-            metadata.groupedTags.size > 1 ||
-            (metadata.groupedTags.size == 1 && metadata.groupedTags[0].category != TagCategory.GENERAL)
-        )
-            return true
+               The images that pass would usually have ungrouped tags, but it could also catch actual
+               images that literally only have general tags. I'm not sure how to work around this. */
+            if (
+                metadata.groupedTags.size > 1 ||
+                (metadata.groupedTags.size == 1 && metadata.groupedTags[0].category != TagCategory.GENERAL)
+            )
+                return true
 
-        /* These image boards would always have grouped tags when viewed outside favourites, so we skip fetching
-           additional info.
-
-           This is for a rare case where the image literally only has one tag group, and it's the general one.
-
-           Unfortunately, if it is a favourited image, we will still attempt to fetch for
-           additional info at least once, in case it was favourited before grouped tags were implemented. */
-        if (
-            !isFavourited &&
-            imageSource in setOf(ImageSource.SAFEBOORU, ImageSource.DANBOORU, ImageSource.R34)
-        ) return true
-
-        return false
-    }
+            return false
+        }
 
     fun copyWithMergedMetadataOverrides(): Image {
         val newMetadata = metadata?.copy(

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -13,6 +13,8 @@ import moe.apex.rule34.util.extractPixivId
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.net.URLEncoder
+import kotlin.collections.joinToString
 
 
 val AI_TAG_NAMES = listOf(
@@ -60,7 +62,8 @@ interface ImageBoard {
         val suggestions = mutableListOf<TagSuggestion>()
         val isExcluded = searchString.startsWith("-")
         val tags = searchString.replace("^-".toRegex(), "")
-        val body = RequestUtil.get(autoCompleteSearchUrl.format(tags)) {
+        val encodedTags = URLEncoder.encode(tags, "utf-8")
+        val body = RequestUtil.get(autoCompleteSearchUrl.format(encodedTags)) {
             addHeader("Referrer", baseUrl)
         }
         val results = JSONArray(body)
@@ -95,28 +98,32 @@ interface ImageBoard {
     suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth? = null): ImageMetadata?
 
     fun formatTagString(tags: List<TagSuggestion>): String {
-        return tags.joinToString("+") { it.formattedLabel }
+        return tags.joinToString(" ") { it.formattedLabel }
     }
 
     fun formatTagNameString(tags: List<String>): String {
-        return tags.joinToString("+")
+        return tags.joinToString(" ")
     }
 
     fun getRatingFromString(rating: String): ImageRating
 
     fun buildImageSearchUrl(tags: String, page: Int, auth: ImageBoardAuth?): String {
+        val encodedTags = URLEncoder.encode(tags, "utf-8")
+
         return if (auth != null) {
-            authenticatedImageSearchUrl.format(tags, page, auth.apiKey, auth.user)
+            authenticatedImageSearchUrl.format(encodedTags, page, auth.apiKey, auth.user)
         } else {
-            imageSearchUrl.format(tags, page)
+            imageSearchUrl.format(encodedTags, page)
         }
     }
 
-    fun buildTagSearchUrl(tags: List<String>, auth: ImageBoardAuth?): String? {
+    fun buildTagSearchUrl(tags: String, auth: ImageBoardAuth?): String? {
+        val encodedTags = URLEncoder.encode(tags, "utf-8")
+
         return if (auth != null) {
-            authenticatedTagSearchUrl?.format(tags.joinToString("+"), auth.apiKey, auth.user)
+            authenticatedTagSearchUrl?.format(encodedTags, auth.apiKey, auth.user)
         } else {
-            tagSearchUrl?.format(tags.joinToString("+"))
+            tagSearchUrl?.format(encodedTags)
         }
     }
 
@@ -333,7 +340,7 @@ object Gelbooru : GelbooruBasedImageBoard {
         val chunkedTags = image.metadata?.tags?.chunked(100) ?: emptyList()
 
         for (i in 0 until chunkedTags.size) {
-            val url = buildTagSearchUrl(chunkedTags[i], auth) ?: return null
+            val url = buildTagSearchUrl(chunkedTags[i].joinToString(" "), auth) ?: return null
             val body = RequestUtil.get(url) {
                 addHeader("Referer", baseUrl)
             }

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -1,6 +1,7 @@
 package moe.apex.rule34.image
 
 import android.util.Log
+import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import moe.apex.rule34.RequestUtil
 import moe.apex.rule34.preferences.ImageSource
@@ -42,6 +43,10 @@ interface ImageBoard {
     val imageSearchUrl: String
     val authenticatedImageSearchUrl: String
         get() = "$imageSearchUrl&api_key=%s&user_id=%s"
+    val tagSearchUrl: String?
+        get() = null
+    val authenticatedTagSearchUrl: String?
+        get() = tagSearchUrl?.let { "$it&api_key=%s&user_id=%s" }
     val apiKeyCreationUrl: String?
         get() = null
     val firstPageIndex: Int
@@ -87,6 +92,8 @@ interface ImageBoard {
 
     suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth? = null): List<Image>
 
+    suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth? = null): ImageMetadata?
+
     fun formatTagString(tags: List<TagSuggestion>): String {
         return tags.joinToString("+") { it.formattedLabel }
     }
@@ -102,6 +109,14 @@ interface ImageBoard {
             authenticatedImageSearchUrl.format(tags, page, auth.apiKey, auth.user)
         } else {
             imageSearchUrl.format(tags, page)
+        }
+    }
+
+    fun buildTagSearchUrl(tags: List<String>, auth: ImageBoardAuth?): String? {
+        return if (auth != null) {
+            authenticatedTagSearchUrl?.format(tags.joinToString("+"), auth.apiKey, auth.user)
+        } else {
+            tagSearchUrl?.format(tags.joinToString("+"))
         }
     }
 
@@ -252,6 +267,11 @@ object Rule34 : GelbooruBasedImageBoard {
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
         return loadPage(tags, page, null, ImageSource.R34, auth)
     }
+
+    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
+        return if (image.hasGroupedTags(isFavourited)) return null
+        else image.id?.let { loadImage(it, auth)?.metadata }
+    }
 }
 
 
@@ -272,6 +292,11 @@ object Safebooru : GelbooruBasedImageBoard {
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
         return loadPage(tags, page, null, ImageSource.SAFEBOORU, auth)
     }
+
+    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
+        return if (image.hasGroupedTags(isFavourited)) return null
+        else image.id?.let { loadImage(it, auth)?.metadata }
+    }
 }
 
 
@@ -280,6 +305,7 @@ object Gelbooru : GelbooruBasedImageBoard {
     override val autoCompleteSearchUrl = "${baseUrl}index.php?page=autocomplete2&term=%s&type=tag_query&limit=10"
     override val autoCompleteCategoryMapping = mapOf("tag" to "general")
     override val imageSearchUrl = "${baseUrl}index.php?page=dapi&json=1&s=post&q=index&limit=100&tags=%s&pid=%d"
+    override val tagSearchUrl = "${baseUrl}index.php?page=dapi&json=1&s=tag&q=index&names=%s"
     override val apiKeyCreationUrl = "${baseUrl}index.php?page=account&s=options"
     override val apiKeyRequirement = ImageBoardRequirement.REQUIRED
 
@@ -293,6 +319,63 @@ object Gelbooru : GelbooruBasedImageBoard {
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
         return loadPage(tags, page, "post", ImageSource.GELBOORU, auth)
+    }
+
+    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
+        if (image.hasGroupedTags(isFavourited)) return null
+
+        val artistTags = mutableListOf<String>()
+        val characterTags = mutableListOf<String>()
+        val copyrightTags = mutableListOf<String>()
+        val generalTags = mutableListOf<String>()
+        val metaTags = mutableListOf<String>()
+
+        val chunkedTags = image.metadata?.tags?.chunked(100) ?: emptyList()
+
+        for (i in 0 until chunkedTags.size) {
+            val url = buildTagSearchUrl(chunkedTags[i], auth) ?: break
+            val body = RequestUtil.get(url) {
+                addHeader("Referer", baseUrl)
+            }
+            if (body.isEmpty()) break
+
+            val json: JSONObject
+
+            try {
+                json = JSONObject(body)
+            } catch (e: JSONException) {
+                break
+            }
+
+            val tagInfoArray = json.optJSONArray("tag") ?: break
+
+            for (i in 0 until tagInfoArray.length()) {
+                val tag = tagInfoArray.getJSONObject(i)
+                val tagType = tag.getString("type")
+                val tagName = tag.getString("name").decodeHtml()
+
+                // Gelbooru's tag types when represented as ints seem to follow Danbooru's autocomplete category mappings
+                when (Danbooru.autoCompleteCategoryMapping[tagType]) {
+                    "artist" -> artistTags.add(tagName)
+                    "copyright" -> copyrightTags.add(tagName)
+                    "character" -> characterTags.add(tagName)
+                    "meta" -> metaTags.add(tagName)
+                    else -> generalTags.add(tagName)
+                }
+            }
+
+            if (i != chunkedTags.size - 1) delay(200)
+        }
+
+        val groupedTags = listOf(
+            TagCategory.CHARACTER.group(characterTags),
+            TagCategory.COPYRIGHT.group(copyrightTags),
+            TagCategory.GENERAL.group(generalTags),
+            TagCategory.META.group(metaTags),
+        )
+            .filter { it.tags.isNotEmpty() }
+
+        return image.metadata?.copy(artists = artistTags, groupedTags = groupedTags)
     }
 }
 
@@ -382,6 +465,11 @@ object Danbooru : ImageBoard {
         return subjects.toList()
     }
 
+    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
+        return if (image.hasGroupedTags(isFavourited)) return null
+        else image.id?.let { loadImage(it, auth)?.metadata }
+    }
+
     override fun getRatingFromString(rating: String): ImageRating {
         return when (rating) {
             "g" -> ImageRating.SAFE
@@ -463,6 +551,10 @@ object Yandere : ImageBoard {
         }
 
         return subjects.toList()
+    }
+
+    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
+        return null // TODO
     }
 
     override fun getRatingFromString(rating: String): ImageRating {

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -95,7 +95,7 @@ interface ImageBoard {
 
     suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth? = null): List<Image>
 
-    suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth? = null): ImageMetadata?
+    suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth? = null): ImageMetadata?
 
     fun formatTagString(tags: List<TagSuggestion>): String {
         return tags.joinToString(" ") { it.formattedLabel }
@@ -275,8 +275,8 @@ object Rule34 : GelbooruBasedImageBoard {
         return loadPage(tags, page, null, ImageSource.R34, auth)
     }
 
-    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
-        return if (image.hasGroupedTags(isFavourited)) return null
+    override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
+        return if (image.hasGroupedTags) return null
         else image.id?.let { loadImage(it, auth)?.metadata }
     }
 }
@@ -300,8 +300,8 @@ object Safebooru : GelbooruBasedImageBoard {
         return loadPage(tags, page, null, ImageSource.SAFEBOORU, auth)
     }
 
-    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
-        return if (image.hasGroupedTags(isFavourited)) return null
+    override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
+        return if (image.hasGroupedTags) return null
         else image.id?.let { loadImage(it, auth)?.metadata }
     }
 }
@@ -328,8 +328,8 @@ object Gelbooru : GelbooruBasedImageBoard {
         return loadPage(tags, page, "post", ImageSource.GELBOORU, auth)
     }
 
-    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
-        if (image.hasGroupedTags(isFavourited)) return null
+    override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
+        if (image.hasGroupedTags) return null
 
         val artistTags = mutableListOf<String>()
         val characterTags = mutableListOf<String>()
@@ -472,8 +472,8 @@ object Danbooru : ImageBoard {
         return subjects.toList()
     }
 
-    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
-        return if (image.hasGroupedTags(isFavourited)) return null
+    override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
+        return if (image.hasGroupedTags) return null
         else image.id?.let { loadImage(it, auth)?.metadata }
     }
 
@@ -560,7 +560,7 @@ object Yandere : ImageBoard {
         return subjects.toList()
     }
 
-    override suspend fun loadImageGroupedTags(image: Image, isFavourited: Boolean, auth: ImageBoardAuth?): ImageMetadata? {
+    override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
         return null // TODO
     }
 

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -347,7 +347,7 @@ object Gelbooru : GelbooruBasedImageBoard {
             try {
                 json = JSONObject(body)
             } catch (e: JSONException) {
-                break
+                return null
             }
 
             val tagInfoArray = json.optJSONArray("tag") ?: return null

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -276,8 +276,7 @@ object Rule34 : GelbooruBasedImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return if (image.hasGroupedTags) return null
-        else image.id?.let { loadImage(it, auth)?.metadata }
+        return image.id?.let { loadImage(it, auth)?.metadata }
     }
 }
 
@@ -301,8 +300,7 @@ object Safebooru : GelbooruBasedImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return if (image.hasGroupedTags) return null
-        else image.id?.let { loadImage(it, auth)?.metadata }
+        return image.id?.let { loadImage(it, auth)?.metadata }
     }
 }
 
@@ -329,8 +327,6 @@ object Gelbooru : GelbooruBasedImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        if (image.hasGroupedTags) return null
-
         val artistTags = mutableListOf<String>()
         val characterTags = mutableListOf<String>()
         val copyrightTags = mutableListOf<String>()
@@ -473,8 +469,7 @@ object Danbooru : ImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return if (image.hasGroupedTags) return null
-        else image.id?.let { loadImage(it, auth)?.metadata }
+        return image.id?.let { loadImage(it, auth)?.metadata }
     }
 
     override fun getRatingFromString(rating: String): ImageRating {

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -333,11 +333,11 @@ object Gelbooru : GelbooruBasedImageBoard {
         val chunkedTags = image.metadata?.tags?.chunked(100) ?: emptyList()
 
         for (i in 0 until chunkedTags.size) {
-            val url = buildTagSearchUrl(chunkedTags[i], auth) ?: break
+            val url = buildTagSearchUrl(chunkedTags[i], auth) ?: return null
             val body = RequestUtil.get(url) {
                 addHeader("Referer", baseUrl)
             }
-            if (body.isEmpty()) break
+            if (body.isEmpty()) return null
 
             val json: JSONObject
 
@@ -347,7 +347,7 @@ object Gelbooru : GelbooruBasedImageBoard {
                 break
             }
 
-            val tagInfoArray = json.optJSONArray("tag") ?: break
+            val tagInfoArray = json.optJSONArray("tag") ?: return null
 
             for (i in 0 until tagInfoArray.length()) {
                 val tag = tagInfoArray.getJSONObject(i)

--- a/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
@@ -45,7 +45,7 @@ enum class ImageRating(override val label: String) : PrefEnum<ImageRating> {
 
         fun buildSearchStringFor(vararg ratings: ImageRating): String {
             val currentFilter = buildQueryListFor(*ratings)
-            return currentFilter.joinToString("+") { it.joinToString("+") }
+            return currentFilter.joinToString(" ") { it.joinToString(" ") }
         }
 
         fun buildSearchStringFor(ratings: Collection<ImageRating>): String {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -627,7 +627,9 @@ private fun LazyListScope.imageboardDataContentItems(
             mainTagsItems(image, onTagClick, onTagLongClick)
         }
 
-        image.metadata!!.groupedTags.filter {
+        val groupedTags = image.metadataGroupedTagsOverride ?: image.metadata?.groupedTags
+
+        groupedTags!!.filter {
             it.category !in setOf(
                 TagCategory.ARTIST,
                 TagCategory.CHARACTER,
@@ -675,7 +677,10 @@ private fun ExpressiveGroupScope.mainTagsItems(
     onTagClick: (String) -> Unit,
     onTagLongClick: (String) -> Unit
 ) {
-    image.metadata!!.artists.takeIf { it.isNotEmpty() }?.let {
+    val artists = image.metadataArtistsOverride ?: image.metadata?.artists
+    val groupedTags = image.metadataGroupedTagsOverride ?: image.metadata?.groupedTags
+
+    artists!!.takeIf { it.isNotEmpty() }?.let {
         item {
             TagsContainer(
                 category = TagCategory.ARTIST,
@@ -686,7 +691,7 @@ private fun ExpressiveGroupScope.mainTagsItems(
         }
     }
 
-    image.metadata.groupedTags.filter {
+    groupedTags!!.filter {
         it.category in setOf(TagCategory.CHARACTER, TagCategory.COPYRIGHT)
     }.forEach { group ->
         item {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -627,9 +627,7 @@ private fun LazyListScope.imageboardDataContentItems(
             mainTagsItems(image, onTagClick, onTagLongClick)
         }
 
-        val groupedTags = image.metadataGroupedTagsOverride ?: image.metadata?.groupedTags
-
-        groupedTags!!.filter {
+        image.metadata!!.groupedTags.filter {
             it.category !in setOf(
                 TagCategory.ARTIST,
                 TagCategory.CHARACTER,
@@ -677,10 +675,7 @@ private fun ExpressiveGroupScope.mainTagsItems(
     onTagClick: (String) -> Unit,
     onTagLongClick: (String) -> Unit
 ) {
-    val artists = image.metadataArtistsOverride ?: image.metadata?.artists
-    val groupedTags = image.metadataGroupedTagsOverride ?: image.metadata?.groupedTags
-
-    artists!!.takeIf { it.isNotEmpty() }?.let {
+    image.metadata!!.artists.takeIf { it.isNotEmpty() }?.let {
         item {
             TagsContainer(
                 category = TagCategory.ARTIST,
@@ -691,7 +686,7 @@ private fun ExpressiveGroupScope.mainTagsItems(
         }
     }
 
-    groupedTags!!.filter {
+    image.metadata.groupedTags.filter {
         it.category in setOf(TagCategory.CHARACTER, TagCategory.COPYRIGHT)
     }.forEach { group ->
         item {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -203,6 +203,7 @@ fun LargeImageView(
     navController: NavController,
     initialPage: Int,
     allImages: List<Image>,
+    onImageUpdate: suspend (Image, Image) -> Unit,
     onZoomedStatusChanged: ((Boolean) -> Unit)? = null
 ) {
     val pagerState = rememberPagerState(
@@ -237,32 +238,16 @@ fun LargeImageView(
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
 
     LaunchedEffect(currentImage) {
-        val favouritedImage =
-            favouriteImages.find { it.fileName == currentImage.fileName && it.imageSource == currentImage.imageSource }
-
         val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
             currentImage,
             prefs.authFor(currentImage.imageSource, context)
         )
 
-        if (currentImage.metadataArtistsOverride == null) {
-            currentImage.metadataArtistsOverride = metadata?.artists ?:
-                currentImage.metadata?.artists ?:
-                emptyList()
-        }
+        if (metadata != null) {
+            val newImage = currentImage.copy(metadata = metadata)
 
-        if (currentImage.metadataGroupedTagsOverride == null) {
-            currentImage.metadataGroupedTagsOverride = metadata?.groupedTags ?:
-                currentImage.metadata?.groupedTags ?:
-                emptyList()
-        }
-
-        if (favouritedImage?.hasGroupedTags == false && currentImage.hasGroupedTags) {
             scope.launch {
-                context.prefs.updateFavouriteImage(
-                    currentImage,
-                    currentImage.copyWithMergedMetadataOverrides()
-                )
+                onImageUpdate(currentImage, newImage)
             }
         }
     }
@@ -442,7 +427,7 @@ private fun LargeImageToolbar(
                             context.prefs.removeFavouriteImage(currentImage)
                             showToast(context, "Removed from your favourites")
                         } else {
-                            context.prefs.addFavouriteImage(currentImage.copyWithMergedMetadataOverrides())
+                            context.prefs.addFavouriteImage(currentImage)
                             showToast(context, "Added to your favourites")
                         }
                     }
@@ -675,7 +660,12 @@ fun LazyLargeImageView(
     else if (image == null)
         ImageNotFound()
     else
-        LargeImageView(navController, 0, listOf(image!!))
+        LargeImageView(
+            navController,
+            0,
+            listOf(image!!),
+            onImageUpdate = { _, newImage -> image = newImage }
+        )
 }
 
 
@@ -1169,6 +1159,7 @@ fun OffsetBasedLargeImageView(
     visibilityState: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>,
+    onImageUpdate: suspend (Image, Image) -> Unit,
     bottomBarVisibleState: MutableState<Boolean>? = null,
 ) {
     val scope = rememberCoroutineScope()
@@ -1296,6 +1287,7 @@ fun OffsetBasedLargeImageView(
                     navController = navController,
                     initialPage = initialPage,
                     allImages = allImages,
+                    onImageUpdate = onImageUpdate,
                     onZoomedStatusChanged = { canDragDown = !it }
                 )
             }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -1158,8 +1158,8 @@ fun OffsetBasedLargeImageView(
     visibilityState: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>,
-    onImageUpdate: suspend (Image, Image) -> Unit,
     bottomBarVisibleState: MutableState<Boolean>? = null,
+    onImageUpdate: suspend (Image, Image) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val density = LocalDensity.current

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -129,6 +129,7 @@ import coil3.network.httpHeaders
 import coil3.request.ImageRequest
 import io.github.kdroidfilter.composemediaplayer.VideoPlayerSurface
 import io.github.kdroidfilter.composemediaplayer.rememberVideoPlayerState
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -252,6 +253,8 @@ fun LargeImageView(
                         onImageUpdate(currentImage, newImage)
                     }
                 }
+            } catch (e: CancellationException) {
+                // Ignore the CancellationException error above because we want it to be cancelled
             } catch (e: Exception) {
                 Log.e("LargeImageView", "Error fetching image grouped tags", e)
             }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -235,8 +235,9 @@ fun LargeImageView(
     }
 
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
+    val hasGroupedTags = remember(currentImage) { currentImage.hasGroupedTags }
 
-    if (!currentImage.hasGroupedTags && onImageUpdate != null) {
+    if (!hasGroupedTags && onImageUpdate != null) {
         LaunchedEffect(currentImage) {
             try {
                 val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -226,7 +226,6 @@ fun LargeImageView(
 
     val context = LocalContext.current
     val prefs = LocalPreferences.current
-    val favouriteImages = prefs.favouriteImages
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(allImages.size) {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -237,12 +237,12 @@ fun LargeImageView(
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
 
     LaunchedEffect(currentImage) {
-        val isFavourited =
-            favouriteImages.any { it.fileName == currentImage.fileName && it.imageSource == currentImage.imageSource }
+        val favouritedImage =
+            favouriteImages.find { it.fileName == currentImage.fileName && it.imageSource == currentImage.imageSource }
 
         val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
             currentImage,
-            isFavourited,
+            favouritedImage != null,
             prefs.authFor(currentImage.imageSource, context)
         )
 
@@ -258,7 +258,7 @@ fun LargeImageView(
                 emptyList()
         }
 
-        if (isFavourited && metadata != null) {
+        if (favouritedImage?.hasGroupedTags(true) == false && currentImage.hasGroupedTags(true)) {
             scope.launch {
                 context.prefs.updateFavouriteImage(
                     currentImage,

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -242,7 +242,6 @@ fun LargeImageView(
 
         val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
             currentImage,
-            favouritedImage != null,
             prefs.authFor(currentImage.imageSource, context)
         )
 
@@ -258,7 +257,7 @@ fun LargeImageView(
                 emptyList()
         }
 
-        if (favouritedImage?.hasGroupedTags(true) == false && currentImage.hasGroupedTags(true)) {
+        if (favouritedImage?.hasGroupedTags == false && currentImage.hasGroupedTags) {
             scope.launch {
                 context.prefs.updateFavouriteImage(
                     currentImage,

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -203,7 +203,7 @@ fun LargeImageView(
     navController: NavController,
     initialPage: Int,
     allImages: List<Image>,
-    onImageUpdate: suspend (Image, Image) -> Unit,
+    onImageUpdate: (suspend (Image, Image) -> Unit)? = null,
     onZoomedStatusChanged: ((Boolean) -> Unit)? = null
 ) {
     val pagerState = rememberPagerState(
@@ -236,18 +236,20 @@ fun LargeImageView(
 
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
 
-    LaunchedEffect(currentImage) {
-        if (!currentImage.hasGroupedTags) {
-            val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
-                currentImage,
-                prefs.authFor(currentImage.imageSource, context)
-            )
+    if (onImageUpdate != null) {
+        LaunchedEffect(currentImage) {
+            if (!currentImage.hasGroupedTags) {
+                val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
+                    currentImage,
+                    prefs.authFor(currentImage.imageSource, context)
+                )
 
-            if (metadata != null) {
-                val newImage = currentImage.copy(metadata = metadata)
+                if (metadata != null) {
+                    val newImage = currentImage.copy(metadata = metadata)
 
-                scope.launch {
-                    onImageUpdate(currentImage, newImage)
+                    scope.launch {
+                        onImageUpdate(currentImage, newImage)
+                    }
                 }
             }
         }
@@ -1161,7 +1163,7 @@ fun OffsetBasedLargeImageView(
     initialPage: Int,
     allImages: List<Image>,
     bottomBarVisibleState: MutableState<Boolean>? = null,
-    onImageUpdate: suspend (Image, Image) -> Unit,
+    onImageUpdate: (suspend (Image, Image) -> Unit)? = null,
 ) {
     val scope = rememberCoroutineScope()
     val density = LocalDensity.current

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -223,6 +223,11 @@ fun LargeImageView(
         derivedStateOf { activeZoomState?.zoomFraction?.let { it < MAX_ZOOM_FOR_PAGE_CHANGE } ?: true }
     }
 
+    val context = LocalContext.current
+    val prefs = LocalPreferences.current
+    val favouriteImages = prefs.favouriteImages
+    val scope = rememberCoroutineScope()
+
     LaunchedEffect(allImages.size) {
         if (pagerState.currentPage >= allImages.size && allImages.isNotEmpty()) {
             pagerState.scrollToPage(allImages.size - 1)
@@ -230,6 +235,38 @@ fun LargeImageView(
     }
 
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
+
+    LaunchedEffect(currentImage) {
+        val isFavourited =
+            favouriteImages.any { it.fileName == currentImage.fileName && it.imageSource == currentImage.imageSource }
+
+        val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
+            currentImage,
+            isFavourited,
+            prefs.authFor(currentImage.imageSource, context)
+        )
+
+        if (currentImage.metadataArtistsOverride == null) {
+            currentImage.metadataArtistsOverride = metadata?.artists ?:
+                currentImage.metadata?.artists ?:
+                emptyList()
+        }
+
+        if (currentImage.metadataGroupedTagsOverride == null) {
+            currentImage.metadataGroupedTagsOverride = metadata?.groupedTags ?:
+                currentImage.metadata?.groupedTags ?:
+                emptyList()
+        }
+
+        if (isFavourited && metadata != null) {
+            scope.launch {
+                context.prefs.updateFavouriteImage(
+                    currentImage,
+                    currentImage.copyWithMergedMetadataOverrides()
+                )
+            }
+        }
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -406,7 +443,7 @@ private fun LargeImageToolbar(
                             context.prefs.removeFavouriteImage(currentImage)
                             showToast(context, "Removed from your favourites")
                         } else {
-                            context.prefs.addFavouriteImage(currentImage)
+                            context.prefs.addFavouriteImage(currentImage.copyWithMergedMetadataOverrides())
                             showToast(context, "Added to your favourites")
                         }
                     }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -236,9 +236,9 @@ fun LargeImageView(
 
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
 
-    if (onImageUpdate != null) {
+    if (!currentImage.hasGroupedTags && onImageUpdate != null) {
         LaunchedEffect(currentImage) {
-            if (!currentImage.hasGroupedTags) {
+            try {
                 val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
                     currentImage,
                     prefs.authFor(currentImage.imageSource, context)
@@ -251,6 +251,8 @@ fun LargeImageView(
                         onImageUpdate(currentImage, newImage)
                     }
                 }
+            } catch (e: Exception) {
+                Log.e("LargeImageView", "Error fetching image grouped tags", e)
             }
         }
     }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -237,16 +237,18 @@ fun LargeImageView(
     val currentImage = allImages[pagerState.currentPage.coerceIn(0, allImages.size - 1)]
 
     LaunchedEffect(currentImage) {
-        val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
-            currentImage,
-            prefs.authFor(currentImage.imageSource, context)
-        )
+        if (!currentImage.hasGroupedTags) {
+            val metadata = currentImage.imageSource.imageBoard.loadImageGroupedTags(
+                currentImage,
+                prefs.authFor(currentImage.imageSource, context)
+            )
 
-        if (metadata != null) {
-            val newImage = currentImage.copy(metadata = metadata)
+            if (metadata != null) {
+                val newImage = currentImage.copy(metadata = metadata)
 
-            scope.launch {
-                onImageUpdate(currentImage, newImage)
+                scope.launch {
+                    onImageUpdate(currentImage, newImage)
+                }
             }
         }
     }

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -660,6 +660,16 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     }
 
 
+    suspend fun updateFavouriteImage(image: Image, newImage: Image) {
+        val images = getPreferences.first().favouriteImages.toMutableList()
+        val index = images.indexOf(image)
+        if (index != -1) {
+            images[index] = newImage
+            updateFavouriteImages(images)
+        }
+    }
+
+
     private fun findDuplicate(incoming: SearchHistoryEntry, history: List<SearchHistoryEntry>): SearchHistoryEntry? {
         /* Since not all ratings are available for all sources, we should only check the
            ones that are available when determining whether a search history entry is a duplicate.


### PR DESCRIPTION
This adds support for Gelbooru grouped tags. For Gelbooru, additional request(s) have to be made to get the proper tag information, so some modifications and methods had to be added under `ImageBoard` to accommodate this.

Support for Yande.re grouped tags are not added, but can easily be extended with this structure.

This also fixes some issues with tags' encoding while building the search URL, which caused autocomplete/search results to be inaccurate.