### PR TITLE
Directly open image from pasted text if it's a valid URL

### DIFF
--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -536,7 +536,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester) {
                                         navController.navigate(imageView)
                                         return@IconButton
                                     }
-                                    val tags = text.split(" ").filter { tag -> tag.trim().isNotEmpty() }
+                                    val tags = text.split("\\s+".toRegex())
                                     if (tags.isEmpty()) {
                                         showToast(context, "No tags to paste")
                                         return@IconButton

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -536,7 +536,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester) {
                                         navController.navigate(imageView)
                                         return@IconButton
                                     }
-                                    val tags = text.split("\\s+".toRegex())
+                                    val tags = text.split("\\s+".toRegex()).toSet()
                                     if (tags.isEmpty()) {
                                         showToast(context, "No tags to paste")
                                         return@IconButton

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -522,7 +522,10 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester) {
                             IconButton(
                                 onClick = {
                                     val text = clipboard.nativeClipboard.primaryClip
-                                        .takeIf { it?.description?.getMimeType(0)?.startsWith("text/") == true }
+                                        .takeIf {
+                                            val mimeType = it?.description?.getMimeType(0)
+                                            mimeType != null && mimeType in setOf("text/plain", "text/x-moz-url")
+                                        }
                                         ?.getItemAt(0)
                                         ?.text
                                         ?.toString()

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -524,7 +524,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester) {
                                     val text = clipboard.nativeClipboard.primaryClip
                                         .takeIf {
                                             val mimeType = it?.description?.getMimeType(0)
-                                            mimeType != null && mimeType in setOf("text/plain", "text/x-moz-url")
+                                            mimeType != null && mimeType in setOf("text/plain", "text/html", "text/x-moz-url")
                                         }
                                         ?.getItemAt(0)
                                         ?.text

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -522,7 +522,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester) {
                             IconButton(
                                 onClick = {
                                     val text = clipboard.nativeClipboard.primaryClip
-                                        .takeIf { it?.description?.getMimeType(0) == "text/plain" }
+                                        .takeIf { it?.description?.getMimeType(0)?.startsWith("text/") == true }
                                         ?.getItemAt(0)
                                         ?.text
                                         ?.toString()

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -94,6 +94,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import kotlinx.coroutines.CancellationException
@@ -104,6 +105,7 @@ import moe.apex.rule34.R
 import moe.apex.rule34.history.SearchHistoryEntry
 import moe.apex.rule34.image.ImageBoardRequirement
 import moe.apex.rule34.image.ImageRating
+import moe.apex.rule34.navigation.ImageView
 import moe.apex.rule34.navigation.Results
 import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
@@ -519,14 +521,23 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester) {
                         Row(Modifier.padding(end = TINY_SPACER.dp)) {
                             IconButton(
                                 onClick = {
-                                    val tags = clipboard.nativeClipboard.primaryClip
+                                    val text = clipboard.nativeClipboard.primaryClip
                                         .takeIf { it?.description?.getMimeType(0) == "text/plain" }
                                         ?.getItemAt(0)
-                                        ?.let {
-                                            it.text.split(" ")
-                                                .filter { tag -> tag.trim().isNotEmpty() }
-                                        }
-                                    if (tags.isNullOrEmpty()) {
+                                        ?.text
+                                        ?.toString()
+                                        ?.trim()
+                                    if (text.isNullOrEmpty()) {
+                                        showToast(context, "Nothing to paste")
+                                        return@IconButton
+                                    }
+                                    val imageView = ImageView.fromUri(text.toUri())
+                                    if (imageView != null) {
+                                        navController.navigate(imageView)
+                                        return@IconButton
+                                    }
+                                    val tags = text.split(" ").filter { tag -> tag.trim().isNotEmpty() }
+                                    if (tags.isEmpty()) {
                                         showToast(context, "No tags to paste")
                                         return@IconButton
                                     }


### PR DESCRIPTION
This makes Breadboard directly open images when pasting a valid image board URL from the clipboard via the paste button. I personally find this useful if I want to directly open an image from a URL without manually copying the ID and using the `id:<id>` tag syntax. This saves the trouble of copying the ID in the first place, typing the `id:<id>` text, copying it again, and then using the paste button.

Also, I've noticed that pasting a tag string that contains duplicate tags will crash the app, so I also fixed that.