### PR TITLE
Support more image board deep links via MD5 hash lookup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,16 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
+                <data android:host="cdn.donmai.us" />
+                <data android:host="*.gelbooru.com" />
+                <data android:host="*.rule34.xxx" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="danbooru.donmai.us" />
 
                 <data android:pathPattern="/posts/.*" />
@@ -66,8 +76,7 @@
                 <data android:pathPattern="/post/show/.*" />
                 <data android:pathAdvancedPattern="/post/show/[0-9]+" />
 
-                <data android:pathPattern="/image/.*/yande.re .*" />
-                <data android:pathAdvancedPattern="/image/[a-z0-9]+/yande.re [0-9]+ .*" />
+                <data android:pathPattern="/image/.*" />
             </intent-filter>
         </activity>
         <provider

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -91,7 +91,9 @@ interface ImageBoard {
 
     fun parseImage(e: JSONObject): Image?
 
-    suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth? = null): Image?
+    suspend fun loadImage(id: String, auth: ImageBoardAuth? = null): Image?
+
+    suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth? = null): Image?
 
     suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth? = null): List<Image>
 
@@ -207,9 +209,13 @@ interface GelbooruBasedImageBoard : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, imageSource, aspectRatio, metadata)
     }
 
-    suspend fun loadImage(imageSource: ImageSource, id: String, isMd5: Boolean, postListKey: String?, auth: ImageBoardAuth? = null): Image? {
-        val tag = if (isMd5) { "md5:$id" } else { id.toIntOrNull()?.let { "id:$id" } ?: return null }
-        return loadPage(imageSource, tag, 0, postListKey, auth).getOrNull(0)
+    suspend fun loadImage(imageSource: ImageSource, id: String, postListKey: String?, auth: ImageBoardAuth? = null): Image? {
+        val parsedId = id.toIntOrNull() ?: return null
+        return loadPage(imageSource, "id:$parsedId", 0, postListKey, auth).getOrNull(0)
+    }
+
+    suspend fun loadImageMd5(imageSource: ImageSource, md5: String, postListKey: String?, auth: ImageBoardAuth? = null): Image? {
+        return loadPage(imageSource, "md5:$md5", 0, postListKey, auth).getOrNull(0)
     }
 
     suspend fun loadPage(imageSource: ImageSource, tags: String, page: Int, postListKey: String?, auth: ImageBoardAuth? = null): List<Image> {
@@ -267,8 +273,12 @@ object Rule34 : GelbooruBasedImageBoard {
         return parseImage(ImageSource.R34, e)
     }
 
-    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        return loadImage(ImageSource.R34, id, isMd5, null, auth)
+    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+        return loadImage(ImageSource.R34, id, null, auth)
+    }
+
+    override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
+        return loadImageMd5(ImageSource.R34, md5, null, auth)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
@@ -276,7 +286,7 @@ object Rule34 : GelbooruBasedImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return image.id?.let { loadImage(it, false, auth)?.metadata }
+        return image.id?.let { loadImage(it, auth)?.metadata }
     }
 }
 
@@ -291,8 +301,12 @@ object Safebooru : GelbooruBasedImageBoard {
         return parseImage(ImageSource.SAFEBOORU, e)
     }
 
-    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        return loadImage(ImageSource.SAFEBOORU, id, isMd5, null, auth)
+    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+        return loadImage(ImageSource.SAFEBOORU, id, null, auth)
+    }
+
+    override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
+        return loadImageMd5(ImageSource.SAFEBOORU, md5, null, auth)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
@@ -300,7 +314,7 @@ object Safebooru : GelbooruBasedImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return image.id?.let { loadImage(it, false, auth)?.metadata }
+        return image.id?.let { loadImage(it, auth)?.metadata }
     }
 }
 
@@ -318,8 +332,12 @@ object Gelbooru : GelbooruBasedImageBoard {
         return parseImage(ImageSource.GELBOORU, e)
     }
 
-    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        return loadImage(ImageSource.GELBOORU, id, isMd5, "post", auth)
+    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+        return loadImage(ImageSource.GELBOORU, id, "post", auth)
+    }
+
+    override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
+        return loadImageMd5(ImageSource.GELBOORU, md5, "post", auth)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
@@ -447,9 +465,13 @@ object Danbooru : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU, aspectRatio, metadata)
     }
 
-    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        val tag = if (isMd5) { "md5:$id" } else { id.toIntOrNull()?.let { "id:$id" } ?: return null }
-        return loadPage(tag, 0, auth).getOrNull(0)
+    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+        val parsedId = id.toIntOrNull() ?: return null
+        return loadPage("id:$parsedId", 0, auth).getOrNull(0)
+    }
+
+    override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
+        return loadPage("md5:$md5", 0, auth).getOrNull(0)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
@@ -469,7 +491,7 @@ object Danbooru : ImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return image.id?.let { loadImage(it, false, auth)?.metadata }
+        return image.id?.let { loadImage(it, auth)?.metadata }
     }
 
     override fun getRatingFromString(rating: String): ImageRating {
@@ -534,9 +556,13 @@ object Yandere : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.YANDERE, aspectRatio, metadata)
     }
 
-    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        val tag = if (isMd5) { "md5:$id" } else { id.toIntOrNull()?.let { "id:$id" } ?: return null }
-        return loadPage(tag, 0).getOrNull(0)
+    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+        val parsedId = id.toIntOrNull() ?: return null
+        return loadPage("id:$parsedId", 0).getOrNull(0)
+    }
+
+    override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
+        return loadPage("md5:$md5", 0).getOrNull(0)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -91,7 +91,7 @@ interface ImageBoard {
 
     fun parseImage(e: JSONObject): Image?
 
-    suspend fun loadImage(id: String, auth: ImageBoardAuth? = null): Image?
+    suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth? = null): Image?
 
     suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth? = null): List<Image>
 
@@ -137,7 +137,7 @@ interface ImageBoard {
 
 
 interface GelbooruBasedImageBoard : ImageBoard {
-    fun parseImage(e: JSONObject, imageSource: ImageSource): Image? {
+    fun parseImage(imageSource: ImageSource, e: JSONObject): Image? {
         val id = e.getString("id")
         val (fileName, fileFormat) = e.getString("image").split('.', limit = 2)
         val fileUrl = e.getString("file_url")
@@ -207,12 +207,13 @@ interface GelbooruBasedImageBoard : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, imageSource, aspectRatio, metadata)
     }
 
-    suspend fun loadImage(id: String, postListKey: String?, imageSource: ImageSource, auth: ImageBoardAuth? = null): Image? {
+    suspend fun loadImage(imageSource: ImageSource, id: String, isMd5: Boolean, postListKey: String?, auth: ImageBoardAuth? = null): Image? {
+        if (isMd5) return loadPage(imageSource, "md5:$id", 0, postListKey, auth).getOrNull(0)
         val parsedId = id.toIntOrNull() ?: return null
-        return loadPage("id:$parsedId", 0, postListKey, imageSource, auth).getOrNull(0)
+        return loadPage(imageSource, "id:$parsedId", 0, postListKey, auth).getOrNull(0)
     }
 
-    suspend fun loadPage(tags: String, page: Int, postListKey: String?, imageSource: ImageSource, auth: ImageBoardAuth? = null): List<Image> {
+    suspend fun loadPage(imageSource: ImageSource, tags: String, page: Int, postListKey: String?, auth: ImageBoardAuth? = null): List<Image> {
         val url = buildImageSearchUrl(tags, page, auth)
         val body = RequestUtil.get(url) {
             addHeader("Referer", baseUrl)
@@ -264,19 +265,19 @@ object Rule34 : GelbooruBasedImageBoard {
     override val apiKeyRequirement = ImageBoardRequirement.NOT_NEEDED
 
     override fun parseImage(e: JSONObject): Image? {
-        return parseImage(e, ImageSource.R34)
+        return parseImage(ImageSource.R34, e)
     }
 
-    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
-        return loadImage(id, null, ImageSource.R34, auth)
+    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
+        return loadImage(ImageSource.R34, id, isMd5, null, auth)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
-        return loadPage(tags, page, null, ImageSource.R34, auth)
+        return loadPage(ImageSource.R34, tags, page, null, auth)
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return image.id?.let { loadImage(it, auth)?.metadata }
+        return image.id?.let { loadImage(it, false, auth)?.metadata }
     }
 }
 
@@ -288,19 +289,19 @@ object Safebooru : GelbooruBasedImageBoard {
     override val imageSearchUrl = "${baseUrl}index.php?page=dapi&json=1&s=post&q=index&limit=100&fields=tag_info&tags=%s&pid=%d"
 
     override fun parseImage(e: JSONObject): Image? {
-        return parseImage(e, ImageSource.SAFEBOORU)
+        return parseImage(ImageSource.SAFEBOORU, e)
     }
 
-    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
-        return loadImage(id, null, ImageSource.SAFEBOORU, auth)
+    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
+        return loadImage(ImageSource.SAFEBOORU, id, isMd5, null, auth)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
-        return loadPage(tags, page, null, ImageSource.SAFEBOORU, auth)
+        return loadPage(ImageSource.SAFEBOORU, tags, page, null, auth)
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return image.id?.let { loadImage(it, auth)?.metadata }
+        return image.id?.let { loadImage(it, false, auth)?.metadata }
     }
 }
 
@@ -315,15 +316,15 @@ object Gelbooru : GelbooruBasedImageBoard {
     override val apiKeyRequirement = ImageBoardRequirement.REQUIRED
 
     override fun parseImage(e: JSONObject): Image? {
-        return parseImage(e, ImageSource.GELBOORU)
+        return parseImage(ImageSource.GELBOORU, e)
     }
 
-    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
-        return loadImage(id, "post", ImageSource.GELBOORU, auth)
+    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
+        return loadImage(ImageSource.GELBOORU, id, isMd5, "post", auth)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
-        return loadPage(tags, page, "post", ImageSource.GELBOORU, auth)
+        return loadPage(ImageSource.GELBOORU, tags, page, "post", auth)
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
@@ -447,7 +448,8 @@ object Danbooru : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU, aspectRatio, metadata)
     }
 
-    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
+        if (isMd5) return loadPage("md5:$id", 0, auth).getOrNull(0)
         val parsedId = id.toIntOrNull() ?: return null
         return loadPage("id:$parsedId", 0, auth).getOrNull(0)
     }
@@ -469,7 +471,7 @@ object Danbooru : ImageBoard {
     }
 
     override suspend fun loadImageGroupedTags(image: Image, auth: ImageBoardAuth?): ImageMetadata? {
-        return image.id?.let { loadImage(it, auth)?.metadata }
+        return image.id?.let { loadImage(it, false, auth)?.metadata }
     }
 
     override fun getRatingFromString(rating: String): ImageRating {
@@ -534,7 +536,8 @@ object Yandere : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.YANDERE, aspectRatio, metadata)
     }
 
-    override suspend fun loadImage(id: String, auth: ImageBoardAuth?): Image? {
+    override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
+        if (isMd5) return loadPage("md5:$id", 0).getOrNull(0)
         val parsedId = id.toIntOrNull() ?: return null
         return loadPage("id:$parsedId", 0).getOrNull(0)
     }

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -208,9 +208,8 @@ interface GelbooruBasedImageBoard : ImageBoard {
     }
 
     suspend fun loadImage(imageSource: ImageSource, id: String, isMd5: Boolean, postListKey: String?, auth: ImageBoardAuth? = null): Image? {
-        if (isMd5) return loadPage(imageSource, "md5:$id", 0, postListKey, auth).getOrNull(0)
-        val parsedId = id.toIntOrNull() ?: return null
-        return loadPage(imageSource, "id:$parsedId", 0, postListKey, auth).getOrNull(0)
+        val tag = if (isMd5) { "md5:$id" } else { id.toIntOrNull()?.let { "id:$id" } ?: return null }
+        return loadPage(imageSource, tag, 0, postListKey, auth).getOrNull(0)
     }
 
     suspend fun loadPage(imageSource: ImageSource, tags: String, page: Int, postListKey: String?, auth: ImageBoardAuth? = null): List<Image> {
@@ -449,9 +448,8 @@ object Danbooru : ImageBoard {
     }
 
     override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        if (isMd5) return loadPage("md5:$id", 0, auth).getOrNull(0)
-        val parsedId = id.toIntOrNull() ?: return null
-        return loadPage("id:$parsedId", 0, auth).getOrNull(0)
+        val tag = if (isMd5) { "md5:$id" } else { id.toIntOrNull()?.let { "id:$id" } ?: return null }
+        return loadPage(tag, 0, auth).getOrNull(0)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
@@ -537,9 +535,8 @@ object Yandere : ImageBoard {
     }
 
     override suspend fun loadImage(id: String, isMd5: Boolean, auth: ImageBoardAuth?): Image? {
-        if (isMd5) return loadPage("md5:$id", 0).getOrNull(0)
-        val parsedId = id.toIntOrNull() ?: return null
-        return loadPage("id:$parsedId", 0).getOrNull(0)
+        val tag = if (isMd5) { "md5:$id" } else { id.toIntOrNull()?.let { "id:$id" } ?: return null }
+        return loadPage(tag, 0).getOrNull(0)
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -267,7 +267,7 @@ fun InfoSheet(navController: NavController, image: Image, onDismissRequest: () -
             val onTagLongClick = { tag: String -> selectedTag = tag }
             val onViewParentClick = { id: String ->
                 hideAndThen {
-                    navController.navigate(ImageView(image.imageSource, id))
+                    navController.navigate(ImageView(image.imageSource, id, false))
                 }
             }
 

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -644,8 +644,9 @@ private fun LargeImageToolbar(
 @Composable
 fun LazyLargeImageView(
     navController: NavController,
-    id: String,
     imageSource: ImageSource,
+    id: String,
+    isMd5: Boolean
 ) {
     val context = LocalContext.current
     val prefs = LocalPreferences.current
@@ -654,7 +655,7 @@ fun LazyLargeImageView(
 
     LaunchedEffect(Unit) {
         try {
-            image = imageSource.imageBoard.loadImage(id, prefs.authFor(imageSource, context))
+            image = imageSource.imageBoard.loadImage(id, isMd5, prefs.authFor(imageSource, context))
         } catch (e: ExecutionException) {
             if (e.cause is SocketTimeoutException) {
                 showToast(context, "Connection timed out")

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -655,7 +655,9 @@ fun LazyLargeImageView(
 
     LaunchedEffect(Unit) {
         try {
-            image = imageSource.imageBoard.loadImage(id, isMd5, prefs.authFor(imageSource, context))
+            val auth = prefs.authFor(imageSource, context)
+            image = if (isMd5) imageSource.imageBoard.loadImageMd5(id, auth)
+                    else imageSource.imageBoard.loadImage(id, auth)
         } catch (e: ExecutionException) {
             if (e.cause is SocketTimeoutException) {
                 showToast(context, "Connection timed out")

--- a/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
@@ -16,7 +16,8 @@ import kotlin.reflect.KClass
 @Serializable
 data class ImageView(
     val source: ImageSource,
-    val id: String
+    val id: String,
+    val isMd5: Boolean
 ) {
     companion object {
         fun fromUri(uri: Uri): ImageView? {
@@ -40,7 +41,7 @@ data class ImageView(
                 }
             } ?: return null
 
-            return ImageView(imageSource, postId)
+            return ImageView(imageSource, postId, false)
         }
     }
 }

--- a/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
@@ -23,25 +23,59 @@ data class ImageView(
         fun fromUri(uri: Uri): ImageView? {
             val imageSource = when (uri.host) {
                 "safebooru.org" -> SAFEBOORU
-                "danbooru.donmai.us" -> DANBOORU
-                "gelbooru.com" -> GELBOORU
+                "danbooru.donmai.us", "cdn.donmai.us" -> DANBOORU
                 "yande.re", "files.yande.re" -> YANDERE
-                "rule34.xxx" -> R34
-                else -> return null
+                else -> {
+                    // Gelbooru and R34 have dynamic CDN subdomains. We'll just handle them here.
+                    if (uri.host == "gelbooru.com" || uri.host?.endsWith(".gelbooru.com") == true) GELBOORU
+                    else if (uri.host == "rule34.xxx" || uri.host?.endsWith(".rule34.xxx") == true) R34
+                    else return null
+                }
             }
 
-            val postId = when (imageSource) {
-                SAFEBOORU,
-                GELBOORU,
-                R34 -> uri.getQueryParameter("id")
-                DANBOORU -> uri.path?.split('/')?.getOrNull(2)
+            var isMd5 = false
+
+            val id = when (imageSource) {
+                SAFEBOORU -> {
+                    /* Safebooru does not have actual image MD5 hashes inside their direct file URLs,
+                       so we cannot load images from them. */
+                    uri.getQueryParameter("id")
+                }
+                DANBOORU -> {
+                    if (uri.host == "danbooru.donmai.us") {
+                        uri.path?.split('/')?.getOrNull(2)
+                    } else {
+                        isMd5 = true
+                        uri.path?.split('/', '_', '-')?.lastOrNull()?.split(".")?.firstOrNull()
+                    }
+                }
+                GELBOORU -> {
+                    if (uri.host == "gelbooru.com") {
+                        uri.getQueryParameter("id")
+                    } else {
+                        isMd5 = true
+                        uri.path?.split('/', '_')?.lastOrNull()?.split(".")?.firstOrNull()
+                    }
+                }
                 YANDERE -> {
-                    val postId = uri.path?.split('/')?.getOrNull(3)
-                    if (uri.host == "files.yande.re") postId?.split(" ")?.getOrNull(1) else postId
+                    if (uri.host == "yande.re") {
+                        uri.path?.split('/')?.getOrNull(3)
+                    } else {
+                        isMd5 = true
+                        uri.path?.split('/')?.getOrNull(2)
+                    }
+                }
+                R34 -> {
+                    if (uri.host == "rule34.xxx") {
+                        uri.getQueryParameter("id")
+                    } else {
+                        isMd5 = true
+                        uri.path?.split('/', '_')?.lastOrNull()?.split(".")?.firstOrNull()
+                    }
                 }
             } ?: return null
 
-            return ImageView(imageSource, postId, false)
+            return ImageView(imageSource, id, isMd5)
         }
     }
 }

--- a/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
@@ -209,7 +209,7 @@ fun Navigation(navController: NavHostController, startDestination: Any = Search)
                 ) {
                     composable<ImageView> {
                         val args = it.toRoute<ImageView>()
-                        LazyLargeImageView(navController, args.id, args.source)
+                        LazyLargeImageView(navController, args.source, args.id, args.isMd5)
                     }
                     composable<Home> { HomeScreen(navController) { isNavigationBarVisible = it } }
                     composable<Search> { SearchScreen(navController, focusRequester) }


### PR DESCRIPTION
This adds deep link support for more image boards (Danbooru, Gelbooru, and R34) via MD5 hash lookups. Yande.re support is also changed to use MD5, as the file names themselves can be basically anything, therefore unreliable to use.

For Safebooru, it appears that their direct URLs do not actually contain the real hashes of the images, so MD5 lookup is not possible.