### PR TITLE
Improve image board file URLs' matching

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,9 +49,18 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="cdn.donmai.us" />
                 <data android:host="*.gelbooru.com" />
                 <data android:host="*.rule34.xxx" />
+
+                <data android:pathPattern="/images/.*" />
+                <data android:pathPattern="/samples/.*" />
+                <data android:pathPattern="/thumbnails/.*" />
+
+                <!-- Gelbooru-based image boards love having an additional slash
+                     at the start of the path for some reason. -->
+                <data android:pathPattern="//images/.*" />
+                <data android:pathPattern="//samples/.*" />
+                <data android:pathPattern="//thumbnails/.*" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -70,13 +79,43 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
+                <data android:host="cdn.donmai.us" />
+
+                <data android:pathPattern="/original/.*" />
+                <data android:pathPattern="/sample/.*" />
+
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="yande.re" />
-                <data android:host="files.yande.re" />
 
                 <data android:pathPattern="/post/show/.*" />
                 <data android:pathAdvancedPattern="/post/show/[0-9]+" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="files.yande.re" />
 
                 <data android:pathPattern="/image/.*" />
+                <data android:pathPattern="/sample/.*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="assets.yande.re" />
+
+                <data android:pathPattern="/data/preview/.*" />
             </intent-filter>
         </activity>
         <activity-alias

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,7 +83,8 @@
 
                 <data android:pathPattern="/original/.*" />
                 <data android:pathPattern="/sample/.*" />
-
+                <data android:pathPattern="/360x360/.*" />
+                <data android:pathPattern="/180x180/.*" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/moe/apex/breadboard/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/breadboard/image/ImageBoard.kt
@@ -215,7 +215,7 @@ interface GelbooruBasedImageBoard : ImageBoard {
     }
 
     suspend fun loadImageMd5(imageSource: ImageSource, md5: String, postListKey: String?, auth: ImageBoardAuth? = null): Image? {
-        return loadPage(imageSource, "md5:$md5", 0, postListKey, auth).getOrNull(0)
+        return loadPage(imageSource, "md5:$md5", 0, postListKey, auth).find { it.fileName == md5 }
     }
 
     suspend fun loadPage(imageSource: ImageSource, tags: String, page: Int, postListKey: String?, auth: ImageBoardAuth? = null): List<Image> {
@@ -471,7 +471,7 @@ object Danbooru : ImageBoard {
     }
 
     override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
-        return loadPage("md5:$md5", 0, auth).getOrNull(0)
+        return loadPage("md5:$md5", 0, auth).find { it.fileName == md5 }
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {
@@ -562,7 +562,7 @@ object Yandere : ImageBoard {
     }
 
     override suspend fun loadImageMd5(md5: String, auth: ImageBoardAuth?): Image? {
-        return loadPage("md5:$md5", 0).getOrNull(0)
+        return loadPage("md5:$md5", 0).find { it.fileName == md5 }
     }
 
     override suspend fun loadPage(tags: String, page: Int, auth: ImageBoardAuth?): List<Image> {

--- a/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
@@ -61,7 +61,7 @@ data class ImageView(
                     }
                 }
                 YANDERE -> {
-                    if (path.startsWith("/post/show")) {
+                    if (path.startsWith("/post/show/")) {
                         path.split('/').getOrNull(3)
                     } else {
                         isMd5 = true

--- a/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
@@ -65,7 +65,7 @@ data class ImageView(
                         path.split('/').getOrNull(3)
                     } else {
                         isMd5 = true
-                        if (path.startsWith("/data/preview"))
+                        if (path.startsWith("/data/preview/"))
                             path.split('/').getOrNull(5)?.split('.')?.firstOrNull()
                         else
                             path.split('/').getOrNull(2)

--- a/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
@@ -21,14 +21,17 @@ data class ImageView(
 ) {
     companion object {
         fun fromUri(uri: Uri): ImageView? {
-            val imageSource = when (uri.host) {
+            val host = uri.host ?: return null
+            val path = uri.path ?: return null
+
+            val imageSource = when (host) {
                 "safebooru.org" -> SAFEBOORU
                 "danbooru.donmai.us", "cdn.donmai.us" -> DANBOORU
-                "yande.re", "files.yande.re" -> YANDERE
+                "yande.re", "files.yande.re", "assets.yande.re" -> YANDERE
                 else -> {
                     // Gelbooru and R34 have dynamic CDN subdomains. We'll just handle them here.
-                    if (uri.host == "gelbooru.com" || uri.host?.endsWith(".gelbooru.com") == true) GELBOORU
-                    else if (uri.host == "rule34.xxx" || uri.host?.endsWith(".rule34.xxx") == true) R34
+                    if (host == "gelbooru.com" || host.endsWith(".gelbooru.com")) GELBOORU
+                    else if (host == "rule34.xxx" || host.endsWith(".rule34.xxx")) R34
                     else return null
                 }
             }
@@ -41,36 +44,31 @@ data class ImageView(
                        so we cannot load images from them. */
                     uri.getQueryParameter("id")
                 }
-                DANBOORU -> {
-                    if (uri.host == "danbooru.donmai.us") {
-                        uri.path?.split('/')?.getOrNull(2)
-                    } else {
-                        isMd5 = true
-                        uri.path?.split('/', '_', '-')?.lastOrNull()?.split(".")?.firstOrNull()
-                    }
-                }
-                GELBOORU -> {
-                    if (uri.host == "gelbooru.com") {
+                GELBOORU, R34 -> {
+                    if (path.startsWith("/index.php")) {
                         uri.getQueryParameter("id")
                     } else {
                         isMd5 = true
-                        uri.path?.split('/', '_')?.lastOrNull()?.split(".")?.firstOrNull()
+                        path.split('/', '_').lastOrNull()?.split('.')?.firstOrNull()
+                    }
+                }
+                DANBOORU -> {
+                    if (path.startsWith("/posts/")) {
+                        path.split('/').getOrNull(2)
+                    } else {
+                        isMd5 = true
+                        path.split('/', '_', '-').lastOrNull()?.split('.')?.firstOrNull()
                     }
                 }
                 YANDERE -> {
-                    if (uri.host == "yande.re") {
-                        uri.path?.split('/')?.getOrNull(3)
+                    if (path.startsWith("/post/show")) {
+                        path.split('/').getOrNull(3)
                     } else {
                         isMd5 = true
-                        uri.path?.split('/')?.getOrNull(2)
-                    }
-                }
-                R34 -> {
-                    if (uri.host == "rule34.xxx") {
-                        uri.getQueryParameter("id")
-                    } else {
-                        isMd5 = true
-                        uri.path?.split('/', '_')?.lastOrNull()?.split(".")?.firstOrNull()
+                        if (path.startsWith("/data/preview"))
+                            path.split('/').getOrNull(5)?.split('.')?.firstOrNull()
+                        else
+                            path.split('/').getOrNull(2)
                     }
                 }
             } ?: return null


### PR DESCRIPTION
Adds support for `asset.yande.re` URLs too, since they are used for index thumbnails.

Also creating this PR because some image boards sometimes serve direct file URLs under the base domain. I believe it depends on how you share/get the images, but it definitely happens and should be considered.