### PR TITLE
Add theme preference

### DIFF
--- a/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
@@ -330,7 +330,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
             PreferenceKeys.INTERNAL_IGNORE_LIST_TIMESTAMP to PrefMeta(PrefCategory.SETTING, exportable = false),
             PreferenceKeys.INTERNAL_IGNORE_LIST to PrefMeta(PrefCategory.SETTING, exportable = false),
             PreferenceKeys.UNIFIED_INFO_SHEET to PrefMeta(PrefCategory.SETTING),
-            PreferenceKeys.THEME to PrefMeta(PrefCategory.SETTINGS)
+            PreferenceKeys.THEME to PrefMeta(PrefCategory.SETTING)
         )
     }
 

--- a/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
@@ -97,6 +97,7 @@ data object PrefNames {
     const val INTERNAL_IGNORE_LIST = "internal_ignore_list"
     const val AUTOPLAY_VIDEOS = "autoplay_videos"
     const val UNIFIED_INFO_SHEET = "unified_info_sheet"
+    const val THEME = "theme"
 }
 
 
@@ -131,6 +132,7 @@ object PreferenceKeys {
     val INTERNAL_IGNORE_LIST = stringSetPreferencesKey(PrefNames.INTERNAL_IGNORE_LIST)
     val AUTOPLAY_VIDEOS = stringPreferencesKey(PrefNames.AUTOPLAY_VIDEOS)
     val UNIFIED_INFO_SHEET = booleanPreferencesKey(PrefNames.UNIFIED_INFO_SHEET)
+    var THEME = stringPreferencesKey(PrefNames.THEME)
 }
 
 
@@ -262,6 +264,7 @@ data class Prefs(
             internalIgnoreList = emptySet(),
             autoplayVideos = AutoplayVideosMode.OFF,
             unifiedInfoSheet = false, // Unified is called 'Classic' in the UI
+            theme = Theme.AUTO,
         )
     }
 
@@ -325,7 +328,8 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
             PreferenceKeys.RECOMMENDATIONS_WEIGHTED_SELECTION to PrefMeta(PrefCategory.SETTING),
             PreferenceKeys.INTERNAL_IGNORE_LIST_TIMESTAMP to PrefMeta(PrefCategory.SETTING, exportable = false),
             PreferenceKeys.INTERNAL_IGNORE_LIST to PrefMeta(PrefCategory.SETTING, exportable = false),
-            PreferenceKeys.UNIFIED_INFO_SHEET to PrefMeta(PrefCategory.SETTING)
+            PreferenceKeys.UNIFIED_INFO_SHEET to PrefMeta(PrefCategory.SETTING),
+            PreferenceKeys.THEME to PrefMeta(PrefCategory.SETTINGS)
         )
     }
 
@@ -853,4 +857,10 @@ enum class ImageSource(override val label: String, val imageBoard: ImageBoard) :
     GELBOORU("Gelbooru", Gelbooru),
     YANDERE("Yande.re", Yandere),
     R34("Rule34", Rule34)
+}
+
+enum class Theme(override val label: String) : PrefEnum<Theme> {
+    DARK("Always use dark mode"),
+    LIGHT("Always use light mode"),
+    AUTO("Use system default")
 }

--- a/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
@@ -813,6 +813,8 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         val autoplayVideos = preferences[PreferenceKeys.AUTOPLAY_VIDEOS]?.let { AutoplayVideosMode.valueOf(it) } ?: Prefs.DEFAULT.autoplayVideos
         val unifiedInfoSheet = preferences[PreferenceKeys.UNIFIED_INFO_SHEET] ?: Prefs.DEFAULT.unifiedInfoSheet
 
+        val theme = preferences[PreferenceKeys.THEME]?.let { Theme.valueOf(it) } ?: Prefs.DEFAULT.theme
+
         return Prefs(
             dataSaver,
             storageLocation,
@@ -843,7 +845,8 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
             internalIgnoreListTimestamp,
             internalIgnoreList,
             autoplayVideos,
-            unifiedInfoSheet
+            unifiedInfoSheet,
+            theme
         )
     }
 }

--- a/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
@@ -230,7 +230,8 @@ data class Prefs(
     val internalIgnoreListTimestamp: Long,
     val internalIgnoreList: Set<String>,
     val autoplayVideos: AutoplayVideosMode,
-    val unifiedInfoSheet: Boolean
+    val unifiedInfoSheet: Boolean,
+    val theme: Theme,
 ) {
     companion object {
         val DEFAULT = Prefs(
@@ -264,7 +265,7 @@ data class Prefs(
             internalIgnoreList = emptySet(),
             autoplayVideos = AutoplayVideosMode.OFF,
             unifiedInfoSheet = false, // Unified is called 'Classic' in the UI
-            theme = Theme.AUTO,
+            theme = Theme.AUTO
         )
     }
 

--- a/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Pref.kt
@@ -97,7 +97,7 @@ data object PrefNames {
     const val INTERNAL_IGNORE_LIST = "internal_ignore_list"
     const val AUTOPLAY_VIDEOS = "autoplay_videos"
     const val UNIFIED_INFO_SHEET = "unified_info_sheet"
-    const val THEME = "theme"
+    const val DARK_THEME = "dark_theme"
 }
 
 
@@ -132,7 +132,7 @@ object PreferenceKeys {
     val INTERNAL_IGNORE_LIST = stringSetPreferencesKey(PrefNames.INTERNAL_IGNORE_LIST)
     val AUTOPLAY_VIDEOS = stringPreferencesKey(PrefNames.AUTOPLAY_VIDEOS)
     val UNIFIED_INFO_SHEET = booleanPreferencesKey(PrefNames.UNIFIED_INFO_SHEET)
-    var THEME = stringPreferencesKey(PrefNames.THEME)
+    var DARK_THEME = stringPreferencesKey(PrefNames.DARK_THEME)
 }
 
 
@@ -231,7 +231,7 @@ data class Prefs(
     val internalIgnoreList: Set<String>,
     val autoplayVideos: AutoplayVideosMode,
     val unifiedInfoSheet: Boolean,
-    val theme: Theme,
+    val darkTheme: DarkTheme,
 ) {
     companion object {
         val DEFAULT = Prefs(
@@ -265,7 +265,7 @@ data class Prefs(
             internalIgnoreList = emptySet(),
             autoplayVideos = AutoplayVideosMode.OFF,
             unifiedInfoSheet = false, // Unified is called 'Classic' in the UI
-            theme = Theme.AUTO
+            darkTheme = DarkTheme.AUTO
         )
     }
 
@@ -330,7 +330,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
             PreferenceKeys.INTERNAL_IGNORE_LIST_TIMESTAMP to PrefMeta(PrefCategory.SETTING, exportable = false),
             PreferenceKeys.INTERNAL_IGNORE_LIST to PrefMeta(PrefCategory.SETTING, exportable = false),
             PreferenceKeys.UNIFIED_INFO_SHEET to PrefMeta(PrefCategory.SETTING),
-            PreferenceKeys.THEME to PrefMeta(PrefCategory.SETTING)
+            PreferenceKeys.DARK_THEME to PrefMeta(PrefCategory.SETTING)
         )
     }
 
@@ -814,7 +814,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         val autoplayVideos = preferences[PreferenceKeys.AUTOPLAY_VIDEOS]?.let { AutoplayVideosMode.valueOf(it) } ?: Prefs.DEFAULT.autoplayVideos
         val unifiedInfoSheet = preferences[PreferenceKeys.UNIFIED_INFO_SHEET] ?: Prefs.DEFAULT.unifiedInfoSheet
 
-        val theme = preferences[PreferenceKeys.THEME]?.let { Theme.valueOf(it) } ?: Prefs.DEFAULT.theme
+        val darkTheme = preferences[PreferenceKeys.DARK_THEME]?.let { DarkTheme.valueOf(it) } ?: Prefs.DEFAULT.darkTheme
 
         return Prefs(
             dataSaver,
@@ -847,7 +847,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
             internalIgnoreList,
             autoplayVideos,
             unifiedInfoSheet,
-            theme
+            darkTheme,
         )
     }
 }
@@ -863,8 +863,8 @@ enum class ImageSource(override val label: String, val imageBoard: ImageBoard) :
     R34("Rule34", Rule34)
 }
 
-enum class Theme(override val label: String) : PrefEnum<Theme> {
-    DARK("Always use dark mode"),
-    LIGHT("Always use light mode"),
-    AUTO("Use system default")
+enum class DarkTheme(override val label: String) : PrefEnum<DarkTheme> {
+    ON("Always"),
+    OFF("Never"),
+    AUTO("Follow system")
 }

--- a/app/src/main/java/moe/apex/breadboard/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Preferences.kt
@@ -365,6 +365,28 @@ fun PreferencesScreen(navController: NavHostController) {
                     }
                 }
             }
+    
+            item { 
+                ExpressiveGroup(title = "Appearance") {
+                    item {
+                        EnumPref(
+                            title = "Theme",
+                            summary = currentSettings.theme.label,
+                            enumItems = Theme.entries,
+                            infoText = "Select Light or Dark to always use that theme, or Auto to follow the system theme.",
+                            selectedItem = currentSettings.theme,
+                            onSelection = {
+                                scope.launch {
+                                    preferencesRepository.updatePref(
+                                        PreferenceKeys.THEME,
+                                        it
+                                    )
+                                }
+                            }
+                        )
+                    }
+                }
+            }
 
             item {
                 ExpressiveGroup(title = "Content") {

--- a/app/src/main/java/moe/apex/breadboard/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/breadboard/preferences/Preferences.kt
@@ -370,15 +370,14 @@ fun PreferencesScreen(navController: NavHostController) {
                 ExpressiveGroup(title = "Appearance") {
                     item {
                         EnumPref(
-                            title = "Theme",
-                            summary = currentSettings.theme.label,
-                            enumItems = Theme.entries,
-                            infoText = "Select Light or Dark to always use that theme, or Auto to follow the system theme.",
-                            selectedItem = currentSettings.theme,
+                            title = "Dark theme",
+                            summary = currentSettings.darkTheme.label,
+                            enumItems = DarkTheme.entries,
+                            selectedItem = currentSettings.darkTheme,
                             onSelection = {
                                 scope.launch {
                                     preferencesRepository.updatePref(
-                                        PreferenceKeys.THEME,
+                                        PreferenceKeys.DARK_THEME,
                                         it
                                     )
                                 }

--- a/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
+++ b/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
@@ -54,7 +54,7 @@ val LocalBreadboardColors = staticCompositionLocalOf {
     )
 }
 
-fun shouldUseDarkMode(): Boolean {
+fun shouldUseDarkTheme(): Boolean {
     val preferences = LocalPreferences.current
 
     val userSelectedDarkMode = preferences.theme == Theme.DARK
@@ -66,7 +66,7 @@ fun shouldUseDarkMode(): Boolean {
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun BreadboardTheme(
-        darkTheme: Boolean = shouldUseDarkMode(),
+        darkTheme: Boolean = shouldUseDarkTheme(),
         // Dynamic color is available on Android 12+
         dynamicColor: Boolean = true,
         content: @Composable () -> Unit

--- a/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
+++ b/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import moe.apex.breadboard.prefs
 
 
 private val DarkColorScheme = darkColorScheme(
@@ -53,11 +54,19 @@ val LocalBreadboardColors = staticCompositionLocalOf {
     )
 }
 
+fun shouldUseDarkMode(): Boolean {
+    val preferences = LocalPreferences.current
+
+    val userSelectedDarkMode = preferences.theme == Theme.DARK
+    val followSystemDarkMode = preferences.theme == Theme.AUTO && isSystemInDarkTheme()
+
+    return userSelectedDarkMode || followSystemDarkMode
+}
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun BreadboardTheme(
-        darkTheme: Boolean = isSystemInDarkTheme(),
+        darkTheme: Boolean = shouldUseDarkMode(),
         // Dynamic color is available on Android 12+
         dynamicColor: Boolean = true,
         content: @Composable () -> Unit

--- a/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
+++ b/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import moe.apex.breadboard.preferences.LocalPreferences
+import moe.apex.breadboard.preferences.Theme
 import moe.apex.breadboard.prefs
 
 
@@ -54,6 +56,7 @@ val LocalBreadboardColors = staticCompositionLocalOf {
     )
 }
 
+@Composable()
 fun shouldUseDarkTheme(): Boolean {
     val preferences = LocalPreferences.current
 

--- a/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
+++ b/app/src/main/java/moe/apex/breadboard/ui/theme/Theme.kt
@@ -15,8 +15,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import moe.apex.breadboard.preferences.LocalPreferences
-import moe.apex.breadboard.preferences.Theme
-import moe.apex.breadboard.prefs
+import moe.apex.breadboard.preferences.DarkTheme
 
 
 private val DarkColorScheme = darkColorScheme(
@@ -56,12 +55,12 @@ val LocalBreadboardColors = staticCompositionLocalOf {
     )
 }
 
-@Composable()
+@Composable
 fun shouldUseDarkTheme(): Boolean {
     val preferences = LocalPreferences.current
 
-    val userSelectedDarkMode = preferences.theme == Theme.DARK
-    val followSystemDarkMode = preferences.theme == Theme.AUTO && isSystemInDarkTheme()
+    val userSelectedDarkMode = preferences.darkTheme == DarkTheme.ON
+    val followSystemDarkMode = preferences.darkTheme == DarkTheme.AUTO && isSystemInDarkTheme()
 
     return userSelectedDarkMode || followSystemDarkMode
 }


### PR DESCRIPTION
This PR:

Introduces a theme selection preference that allows users to select a preferred theme. The options are `DARK`, `LIGHT`, and `AUTO`. 

- `DARK`: always use dark theme
- `LIGHT`: always use light theme
- `AUTO`: follow system preferences (default, old behaviour)

Adds a section `Appearance` to the preferences page, with the aforementioned theme selection.  