### PR TITLE
Account for an additional hash in pixiv image URLs

### DIFF
--- a/app/src/main/java/moe/apex/breadboard/util/Pixiv.kt
+++ b/app/src/main/java/moe/apex/breadboard/util/Pixiv.kt
@@ -4,7 +4,8 @@ package moe.apex.breadboard.util
 private val PIXIV_CURRENT_RX =
     // https://i.pximg.net/img-original/img/2022/11/27/21/27/08/103150283_p0.jpg (Safebooru #6517847)
     // https://i.pximg.net/img-master/img/2019/07/09/08/27/59/75629295_p0_master1200.jpg (Safebooru #3567627)
-    """https?://i\.pximg\.net/img-(original|master)/img/\d+/\d+/\d+/\d+/\d+/\d+/(?<id>\d+)_p(?<index>\d+)(_master1200)?\.(png|jpg|jpeg|gif)""".toRegex()
+    // https://i.pximg.net/img-original/img/2026/05/13/20/30/05/144732134-2ec1cc9314f12cef1751801f82cc21a0_p0.jpg (Safebooru #6757725)
+    """https?://i\.pximg\.net/img-(original|master)/img/\d+/\d+/\d+/\d+/\d+/\d+/(?<id>\d+)(-[0-9a-f]+)?_p(?<index>\d+)(_master1200)?\.(png|jpg|jpeg|gif)""".toRegex()
 
 // 2012-2016 pixiv direct image URLs
 private val PIXIV_2012_TO_2016_RX = listOf(


### PR DESCRIPTION
Perhaps we want to make sure that the hash part is consistent and not some arbitrary text before merging? So far, only <https://www.pixiv.net/en/users/6936667>'s recent artworks have that kind of naming.